### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,7 +59,7 @@ TODO
 Suggested ideas
 ===============
 * (evilmode) add option to disable entropy gathering and instead constantly feed '1' into the entropy pool
-* (maybe?) write a file to echo random bytes to the system sound output device? could break compability for some systems
+* (maybe?) write a file to echo random bytes to the system sound output device? could break compatibility for some systems
 * randomly allocate a bunch of memory
 * (maybe) create a bunch of files here and there?
 * ...your ideas go here!


### PR DESCRIPTION
@oniichaNj, I've corrected a typographical error in the documentation of the [headached](https://github.com/oniichaNj/headached) project. Specifically, I've changed compability to compatibility. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
